### PR TITLE
Bugfix page ranges that do not start with 1 as gs outputs pages start…

### DIFF
--- a/src/PDFLib.php
+++ b/src/PDFLib.php
@@ -129,10 +129,9 @@ class PDFLib{
         $output = $this->executeGS("-dSAFER -dBATCH -dNOPAUSE -sDEVICE=".$this->imageDeviceCommand." ".$this->pngDownScaleFactor." -r".$this->resolution." -dNumRenderingThreads=4 -dFirstPage=".$this->page_start." -dLastPage=".$this->page_end." -o\"".$image_path."\" -dJPEGQ=".$this->jpeg_quality." -q \"".($this->pdf_path)."\" -c quit");
 
         $fileArray = [];
-        for($i=($this->page_start); $i<=$this->page_end; ++$i){
+        for($i=1; $i<=($this->page_end - $this->page_start + 1); ++$i){
             $fileArray[] = "page-$i.".$this->imageExtention;
         }
-
         if(!$this->checkFilesExists($this->output_path,$fileArray)){
             $errrorinfo = implode(",", $output);
             throw new \Exception('PDF_CONVERSION_ERROR '.$errrorinfo);


### PR DESCRIPTION
…ing with 1 regardless of the actual page in the pdf

In my case I was pulling out a single page (page 5) of a document. Ghostscript creates a file called page-1.png - so the code was failing looking for page-5.png when it didn't exist.