### PR TITLE
Fix getNumberOfPages command

### DIFF
--- a/src/PDFLib.php
+++ b/src/PDFLib.php
@@ -101,7 +101,7 @@ class PDFLib{
 
     public function getNumberOfPages(){
         if($this->number_of_pages == -1){
-            $pages = $this->executeGS('-q -dNODISPLAY -c "("'.$this->pdf_path.'") (r) file runpdfbegin pdfpagecount = quit"',true);
+            $pages = $this->executeGS('-q -dNODISPLAY -c "('.$this->pdf_path.') (r) file runpdfbegin pdfpagecount = quit"',true);
             $this->number_of_pages = intval($pages);
         }
         return $this->number_of_pages;


### PR DESCRIPTION
The issuing of multiple unescaped double quotes was breaking this command on linux. Wrapping with double quotes is not necessary even if the filename as spaces etc.