### PR TITLE
Unable to handle in Windows because .gitignore is duplicated

### DIFF
--- a/.gitIgnore
+++ b/.gitIgnore
@@ -1,5 +1,0 @@
-.idea
-.idea/**
-vendor
-composer.lock
-/tests/data

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-composer.lock
+.idea
+.idea/**
 vendor
+composer.lock
+/tests/data


### PR DESCRIPTION
Due to the presence of .gitignore and .gitIgnore, it is not possible to "git clone" properly in a windows environment.
"composer require" cannot be performed normally even in Docker on Windows.

### git clone

```text
$ git clone https://github.com/imalhasaranga/PDFLib.git
Cloning into 'PDFLib'...
remote: Enumerating objects: 155, done.
Receiving objectsremote: Total 155 (delta 0), reused 0 (delta 0), pack-reused 155
Receiving objects: 100% (155/155), 434.03 KiB | 720.00 KiB/s, done.
Resolving deltas: 100% (76/76), done.
warning: the following paths have collided (e.g. case-sensitive paths
on a case-insensitive filesystem) and only one from the same
colliding group is in the working tree:

  '.gitIgnore'
  '.gitignore'

$
```

### composer require
```text
root@e53aba0fceac:/var/www# composer require imal-h/pdf-box
Using version ^1.3 for imal-h/pdf-box
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Updating imal-h/pdf-box (1.2.2 => 1.3.0): Downloading (100%)    Update failed (Could not delete /var/www/vendor/composer/efed77db/imalhasaranga-PDFLib-771b3
f9/.gitIgnore: )
    Would you like to try reinstalling the package instead [yes]? yes
  - Removing imal-h/pdf-box (1.2.2)
  - Installing imal-h/pdf-box (1.3.0): Downloading (100%)
    Failed to download imal-h/pdf-box from dist: Could not delete /var/www/vendor/composer/6112bffc/imalhasaranga-PDFLib-771b3f9/.gitIgnore:
    Now trying to download from source
  - Installing imal-h/pdf-box (1.3.0): Cloning 771b3f92be from cache
    771b3f92be53186f86656f6fe41dec0c2bee2e28 is gone (history was rewritten?)

Installation failed, reverting ./composer.json to its original content.


  [RuntimeException]
  Failed to execute git checkout '771b3f92be53186f86656f6fe41dec0c2bee2e28' -- && git reset --hard '771b3f92be53186f86656f6fe41dec0c2bee2e28' --

  HEAD is now at 771b3f9 Merge pull request #14 from joshbmarshall/master
  error: unable to unlink old '.gitignore': Device or resource busy
  fatal: Could not reset index file to revision '771b3f92be53186f86656f6fe41dec0c2bee2e28'.


require [--dev] [--prefer-source] [--prefer-dist] [--no-progress] [--no-suggest] [--no-update] [--no-scripts] [--update-no-dev] [--update-with-dependencies] [--
update-with-all-dependencies] [--ignore-platform-reqs] [--prefer-stable] [--prefer-lowest] [--sort-packages] [-o|--optimize-autoloader] [-a|--classmap-authorita
tive] [--apcu-autoloader] [--] [<packages>]...

root@e53aba0fceac:/var/www#
```