### PR TITLE
Added missing $file_prefix property - fix for dynamic property creation PHP depraction

### DIFF
--- a/src/PDFLib.php
+++ b/src/PDFLib.php
@@ -34,6 +34,7 @@ class PDFLib{
     private $imageDeviceCommand;
     private $imageExtention;
     private $pngDownScaleFactor;
+    private $file_prefix;
 
     private $is_os_win = null;
     private $gs_command = null;


### PR DESCRIPTION
Since PHP 8.2 creation of class properties dynamically is deprecated.
https://php.watch/versions/8.2/dynamic-properties-deprecated

This PR simply adds missing property which PHP complains about :wink: